### PR TITLE
Updated config.sh to point to the reproducibility branch of config repository

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,1 +1,1 @@
-MAPPING_URL=https://raw.githubusercontent.com/sfu-ireceptor/config/master/AIRR-iReceptorMapping.txt
+MAPPING_URL=https://raw.githubusercontent.com/sfu-ireceptor/config/reproducibility/AIRR-iReceptorMapping.txt


### PR DESCRIPTION
This aims to add support for reproducibility, by adding 3 fields:

1. Inputs - A string representing an URL from which the input datasets can be fetched programmatically.
2. Command - A machine-readable command to be executed in order to reproduce the processing made to the data.
3. Outputs - A string representing an URL from which the output datasets can be fetched programmatically.

For this pull request to work, the pull request to the config repository, reproducibility branch, needs to be merged first, because this points to the AIRR-Mapping file that exists there.

The merge request to the config repository can be found on the following url:
https://github.com/sfu-ireceptor/config/pull/10